### PR TITLE
Fixed JavaDoc linking to method with a changed name.

### DIFF
--- a/src/api/java/com/ldtteam/aequivaleo/api/recipe/equivalency/calculator/IRecipeCalculator.java
+++ b/src/api/java/com/ldtteam/aequivaleo/api/recipe/equivalency/calculator/IRecipeCalculator.java
@@ -96,7 +96,7 @@ public interface IRecipeCalculator
     /**
      * This methods is for your convenience:
      * It converts the vanilla {@link Ingredient#getItems()} to a list of {@link IRecipeIngredient}
-     * respecting the relevant {@link ItemStack#getContainerItem()} stacks.
+     * respecting the relevant {@link ItemStack#getCraftingRemainingItem()} ()} stacks.
      *
      * @param ingredient The ingredient to handle.
      * @return All of the recipe ingredients which it represents, respecting the container item.


### PR DESCRIPTION
I think this _should_ be the last of the changes for the port to 94+. Can't find any more JDoc issues. If there are, IntelliJ is lying to me.